### PR TITLE
Generic index call

### DIFF
--- a/cli/test.js
+++ b/cli/test.js
@@ -75,7 +75,7 @@ squad.on('open', async () => {
   const r = await squad.getElement(a)
   console.log("roshambo retrieved:", r)
 
-  const g = await squad.getAllElementsOfType("Game")
+  const g = await squad.getElementsFromIndex("Game", "Game Index")
   console.log("all games:", g)
 
   const componentAdds = await Promise.all(
@@ -98,6 +98,9 @@ squad.on('open', async () => {
 
   const f = await squad.createElement(standard)
   console.log("format address:", f)
+
+  const z = await squad.getElement(f)
+  console.log("standard format retrieved:", z)
 
   const h = await squad.getAllElementsOfType("Format")
   console.log("all formats:", h)

--- a/cli/test.js
+++ b/cli/test.js
@@ -75,7 +75,7 @@ squad.on('open', async () => {
   const r = await squad.getElement(a)
   console.log("roshambo retrieved:", r)
 
-  const g = await squad.getAllGames()
+  const g = await squad.getAllElementsOfType("Game")
   console.log("all games:", g)
 
   const componentAdds = await Promise.all(
@@ -86,7 +86,7 @@ squad.on('open', async () => {
 
   console.log("component addresses:", componentAdds)
 
-  const c = await squad.getAllComponents()
+  const c = await squad.getAllElementsOfType("Component")
   console.log("all components:", c)
 
   const standard = {
@@ -99,7 +99,7 @@ squad.on('open', async () => {
   const f = await squad.createElement(standard)
   console.log("format address:", f)
 
-  const h = await squad.getAllFormats()
+  const h = await squad.getAllElementsOfType("Format")
   console.log("all formats:", h)
 
   console.log("standard format components addresses:", h[0].Format.components)

--- a/cli/test.js
+++ b/cli/test.js
@@ -75,19 +75,24 @@ squad.on('open', async () => {
   const r = await squad.getElement(a)
   console.log("roshambo retrieved:", r)
 
-  const g = await squad.getElementsFromIndex("Game", "Game Index")
-  console.log("all games:", g)
+  setTimeout(async () => {
+    const g = await squad.getElementsFromIndex("Game", "Game Index")
+    console.log("all games:", g)
+  },
+  1000)
 
   const componentAdds = await Promise.all(
     components.map(async c => {
       return squad.createElement(c) 
     })
   )
-
   console.log("component addresses:", componentAdds)
 
-  const c = await squad.getAllElementsOfType("Component")
-  console.log("all components:", c)
+  setTimeout(async () => {
+    const c = await squad.getAllElementsOfType("Component")
+    console.log("all components:", c)
+  },
+  1000)
 
   const standard = {
     Format: {
@@ -102,9 +107,11 @@ squad.on('open', async () => {
   const z = await squad.getElement(f)
   console.log("standard format retrieved:", z)
 
-  const h = await squad.getAllElementsOfType("Format")
-  console.log("all formats:", h)
-
-  console.log("standard format components addresses:", h[0].Format.components)
+  setTimeout(async () => {
+    const h = await squad.getAllElementsOfType("Format")
+    console.log("all formats:", h)
+    console.log("standard format components addresses:", h[0].Format.components)
+  },
+  1000)
 
 })

--- a/sdk/js/index.js
+++ b/sdk/js/index.js
@@ -104,16 +104,8 @@ const getElement = async (address) => {
   return await call("elements", "get_element", {address})
 }
 
-const getAllGames = async () => {
-  return await call("elements", "get_all_games", {})
-}
-
-const getAllFormats = async () => {
-  return await call("elements", "get_all_formats", {})
-}
-
-const getAllComponents = async () => {
-  return await call("elements", "get_all_components", {})
+const getAllElementsOfType = async (index_type) => {
+  return await call("elements", "get_all_elements_of_type", {index_type})
 }
 
 module.exports = {
@@ -125,7 +117,5 @@ module.exports = {
   call,
   createElement,
   getElement,
-  getAllGames,
-  getAllFormats,
-  getAllComponents
+  getAllElementsOfType
 }

--- a/sdk/js/index.js
+++ b/sdk/js/index.js
@@ -104,8 +104,12 @@ const getElement = async (address) => {
   return await call("elements", "get_element", {address})
 }
 
-const getAllElementsOfType = async (index_type) => {
+const getAllElementsOfType = async (index_type, index_name) => {
   return await call("elements", "get_all_elements_of_type", {index_type})
+}
+
+const getElementsFromIndex = async (index_type, index_name) => {
+  return await call("elements", "get_elements_from_index", {index_type, index_name})
 }
 
 module.exports = {
@@ -117,5 +121,6 @@ module.exports = {
   call,
   createElement,
   getElement,
-  getAllElementsOfType
+  getAllElementsOfType,
+  getElementsFromIndex
 }

--- a/sdk/js/index.js
+++ b/sdk/js/index.js
@@ -104,7 +104,7 @@ const getElement = async (address) => {
   return await call("elements", "get_element", {address})
 }
 
-const getAllElementsOfType = async (index_type, index_name) => {
+const getAllElementsOfType = async (index_type) => {
   return await call("elements", "get_all_elements_of_type", {index_type})
 }
 

--- a/zomes/elements/code/src/lib.rs
+++ b/zomes/elements/code/src/lib.rs
@@ -138,7 +138,23 @@ fn handle_get_element_index(address: Address) -> ZomeApiResult<ElementIndex> {
 }
 
 fn handle_get_all_elements_of_type(index_type: String) -> ZomeApiResult<Vec<Element>> {
-    let index_name: String = format!("{} Index", index_type.clone());
+    let index_name: String = index_type.clone() + " Index";
+    let index = ElementIndex {
+        name: index_name.clone(),
+        type_: index_type
+    };
+
+    let index_entry = Entry::App("ElementIndex".into(), index.into());
+    let address: Address = entry_address(&index_entry)?;
+
+    let links: Vec<Address> = get_links(&address, Some("Index".to_string()), None)?.addresses();
+    let elements: Vec<Element> = links.into_iter().map(|address| {
+        handle_get_element(address).unwrap()
+    }).collect();
+    Ok(elements)
+}
+
+fn handle_get_elements_from_index(index_type: String, index_name: String) -> ZomeApiResult<Vec<Element>> {
     let index = ElementIndex {
         name: index_name.clone(),
         type_: index_type
@@ -190,6 +206,11 @@ define_zome! {
             outputs: |linked_elements: ZomeApiResult<Vec<Element>>|,
             handler: handle_get_all_elements_of_type
         }
+        get_elements_from_index: {
+            inputs: |index_type: String, index_name: String|,
+            outputs: |linked_elements: ZomeApiResult<Vec<Element>>|,
+            handler: handle_get_elements_from_index
+        }
     ]
 
     traits: {
@@ -198,7 +219,8 @@ define_zome! {
             // create_element_index, 
             get_element, 
             get_element_index,
-            get_all_elements_of_type
+            get_all_elements_of_type,
+            get_elements_from_index
         ]
     }
 }

--- a/zomes/elements/code/src/lib.rs
+++ b/zomes/elements/code/src/lib.rs
@@ -145,7 +145,7 @@ fn handle_get_all_elements_of_type(index_type: String) -> ZomeApiResult<Vec<Elem
     };
 
     let index_entry = Entry::App("ElementIndex".into(), index.into());
-    let address: Address = hdk::commit_entry(&index_entry)?;
+    let address: Address = entry_address(&index_entry)?;
 
     let links: Vec<Address> = get_links(&address, Some("Index".to_string()), None)?.addresses();
     let elements: Vec<Element> = links.into_iter().map(|address| {
@@ -161,7 +161,7 @@ fn handle_get_elements_from_index(index_type: String, index_name: String) -> Zom
     };
 
     let index_entry = Entry::App("ElementIndex".into(), index.into());
-    let address: Address = hdk::commit_entry(&index_entry)?;
+    let address: Address = entry_address(&index_entry)?;
 
     let links: Vec<Address> = get_links(&address, Some("Index".to_string()), None)?.addresses();
     let elements: Vec<Element> = links.into_iter().map(|address| {

--- a/zomes/elements/code/src/lib.rs
+++ b/zomes/elements/code/src/lib.rs
@@ -145,7 +145,7 @@ fn handle_get_all_elements_of_type(index_type: String) -> ZomeApiResult<Vec<Elem
     };
 
     let index_entry = Entry::App("ElementIndex".into(), index.into());
-    let address: Address = entry_address(&index_entry)?;
+    let address: Address = hdk::commit_entry(&index_entry)?;
 
     let links: Vec<Address> = get_links(&address, Some("Index".to_string()), None)?.addresses();
     let elements: Vec<Element> = links.into_iter().map(|address| {
@@ -161,7 +161,7 @@ fn handle_get_elements_from_index(index_type: String, index_name: String) -> Zom
     };
 
     let index_entry = Entry::App("ElementIndex".into(), index.into());
-    let address: Address = entry_address(&index_entry)?;
+    let address: Address = hdk::commit_entry(&index_entry)?;
 
     let links: Vec<Address> = get_links(&address, Some("Index".to_string()), None)?.addresses();
     let elements: Vec<Element> = links.into_iter().map(|address| {


### PR DESCRIPTION
Switched to `get_elements_from_index(index_type, index_name)` and `get_all_elements_of_type`, for more generic index calls.

I'm using `hdk::commit_entry` instead of `entry_address` still, because `entry_address` seems to miss some of the links sometimes right now -- could be something to do with the way it's "recreating" the address, although that doesn't really make sense to me. The one works better than the other for me right now, so I went with it.